### PR TITLE
 add support for jvmTarget to the kotlin compiler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-kotlin "0.0.2.0"
+(defproject hellonico/lein-kotlin "0.0.2.1"
   :description "A Leiningen plugin to compile Kotlin code."
   :url "https://github.com/reutermj/lein-kotlin"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-kotlin "0.0.2"
+(defproject lein-kotlin "0.0.2.0"
   :description "A Leiningen plugin to compile Kotlin code."
   :url "https://github.com/reutermj/lein-kotlin"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hellonico/lein-kotlin "0.0.2.1"
+(defproject hellonico/lein-kotlin "0.0.2.2"
   :description "A Leiningen plugin to compile Kotlin code."
   :url "https://github.com/reutermj/lein-kotlin"
   :license {:name "MIT License"

--- a/src/leiningen/kotlin.clj
+++ b/src/leiningen/kotlin.clj
@@ -8,7 +8,7 @@
   (let [ksrc (:kotlin-source-path project)
         target (or (:compile-path project) "target")
         jvmTarget (or (:kotlin-java-version project) "1.8")
-        version (or (:kotlin-compiler-version project) "1.1.4-3")
+        version (or (:kotlin-compiler-version project) "1.1.51")
         p (merge-profiles project [{:dependencies [['org.jetbrains.kotlin/kotlin-compiler version]]}])
         p (dissoc p :prep-tasks)]
     (when ksrc
@@ -16,5 +16,5 @@
         p
         `(do
            (org.jetbrains.kotlin.cli.jvm.K2JVMCompiler/main
-             ; (into-array ["jvmTarget" jvmTarget "-cp" (System/getProperty "java.class.path") "-d" ~target ~ksrc])))))))
-             (into-array [ "-no-stdlib" "-Xskip-runtime-version-check" "-cp" (System/getProperty "java.class.path") "-d" ~target ~ksrc])))))))
+             ; (into-array ["-jvmTarget" jvmTarget "-cp" (System/getProperty "java.class.path") "-d" ~target ~ksrc])))))))
+             (into-array ["-Xskip-runtime-version-check" "-no-stdlib" "-Xskip-runtime-version-check" "-cp" (System/getProperty "java.class.path") "-jvm-target" "1.8" "-d" ~target ~ksrc])))))))

--- a/src/leiningen/kotlin.clj
+++ b/src/leiningen/kotlin.clj
@@ -17,4 +17,4 @@
         `(do
            (org.jetbrains.kotlin.cli.jvm.K2JVMCompiler/main
              ; (into-array ["jvmTarget" jvmTarget "-cp" (System/getProperty "java.class.path") "-d" ~target ~ksrc])))))))
-             (into-array ["-cp" (System/getProperty "java.class.path") "-d" ~target ~ksrc])))))))
+             (into-array [ "-no-stdlib" "-Xskip-runtime-version-check" "-cp" (System/getProperty "java.class.path") "-d" ~target ~ksrc])))))))

--- a/src/leiningen/kotlin.clj
+++ b/src/leiningen/kotlin.clj
@@ -7,7 +7,8 @@
   [project & args]
   (let [ksrc (:kotlin-source-path project)
         target (or (:compile-path project) "target")
-        version (or (:kotlin-compiler-version project) "1.0.1-2")
+        jvmTarget (or (:kotlin-java-version project) "1.8")
+        version (or (:kotlin-compiler-version project) "1.1.4-3")
         p (merge-profiles project [{:dependencies [['org.jetbrains.kotlin/kotlin-compiler version]]}])
         p (dissoc p :prep-tasks)]
     (when ksrc
@@ -15,4 +16,5 @@
         p
         `(do
            (org.jetbrains.kotlin.cli.jvm.K2JVMCompiler/main
+             ; (into-array ["jvmTarget" jvmTarget "-cp" (System/getProperty "java.class.path") "-d" ~target ~ksrc])))))))
              (into-array ["-cp" (System/getProperty "java.class.path") "-d" ~target ~ksrc])))))))


### PR DESCRIPTION
needed support for jvm target 1.8  (seems the default is 1.6 for inlined bytecode)  